### PR TITLE
Automate GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,6 @@ jobs:
           
           # Save to file for multi-line output
           echo "$CHANGELOG" > changelog.txt
-          echo "PREV_TAG=$PREV_TAG" >> $GITHUB_OUTPUT
       
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      
+      - name: Verify manifest version
+        run: |
+          MANIFEST_VERSION=$(jq -r '.version' manifest.json)
+          TAG_VERSION="${{ steps.get_version.outputs.VERSION }}"
+          echo "Manifest version: $MANIFEST_VERSION"
+          echo "Tag version: $TAG_VERSION"
+          if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
+            echo "::warning::Manifest version ($MANIFEST_VERSION) does not match tag version ($TAG_VERSION)"
+          fi
+      
+      - name: Create extension package
+        run: |
+          mkdir -p dist
+          zip -r dist/kibana-as-code-v${{ steps.get_version.outputs.VERSION }}.zip \
+            manifest.json \
+            background/ \
+            content/ \
+            popup/ \
+            sidepanel/ \
+            README.MD \
+            -x "*.git*" "*.DS_Store"
+          
+          echo "Package created:"
+          ls -lh dist/
+      
+      - name: Generate changelog
+        id: changelog
+        run: |
+          # Get the previous tag
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${GITHUB_REF#refs/tags/}$" | head -n 1)
+          
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, using initial commit"
+            PREV_TAG=$(git rev-list --max-parents=0 HEAD)
+          fi
+          
+          echo "Generating changelog from $PREV_TAG to ${GITHUB_REF#refs/tags/}"
+          
+          # Generate changelog
+          CHANGELOG=$(git log $PREV_TAG..HEAD --pretty=format:"- %s (%h)" --no-merges)
+          
+          if [ -z "$CHANGELOG" ]; then
+            CHANGELOG="- Initial release"
+          fi
+          
+          # Save to file for multi-line output
+          echo "$CHANGELOG" > changelog.txt
+          echo "PREV_TAG=$PREV_TAG" >> $GITHUB_OUTPUT
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*.zip
+          body_path: changelog.txt
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension
+          path: dist/*.zip
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       
       - name: Get version from tag
         id: get_version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,71 @@
+# Release Process
+
+This project uses GitHub Actions to automate releases. When you push a version tag, the workflow automatically builds and packages the Chrome extension.
+
+## Creating a Release
+
+1. **Update the version in `manifest.json`**
+   ```bash
+   # Edit manifest.json and update the version field
+   # Example: "version": "1.0.1"
+   ```
+
+2. **Commit the version change**
+   ```bash
+   git add manifest.json
+   git commit -m "Bump version to 1.0.1"
+   ```
+
+3. **Create and push a git tag**
+   ```bash
+   # Tag format: v{MAJOR}.{MINOR}.{PATCH}
+   git tag v1.0.1
+   git push origin v1.0.1
+   ```
+
+4. **GitHub Actions will automatically:**
+   - Package the extension as a ZIP file
+   - Generate a changelog from git commits
+   - Create a GitHub Release with the packaged extension
+   - Upload the extension as a downloadable artifact
+
+## What Gets Packaged
+
+The release workflow packages the following files into the ZIP:
+- `manifest.json`
+- `background/` directory
+- `content/` directory  
+- `popup/` directory
+- `sidepanel/` directory
+- `README.MD`
+
+Git files and macOS metadata (`.DS_Store`) are excluded.
+
+## Release Naming
+
+The packaged extension will be named: `kibana-as-code-v{VERSION}.zip`
+
+Example: `kibana-as-code-v1.0.1.zip`
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+- **MAJOR** version for incompatible API changes
+- **MINOR** version for new functionality in a backwards compatible manner
+- **PATCH** version for backwards compatible bug fixes
+
+## Troubleshooting
+
+### Version Mismatch Warning
+
+If the version in `manifest.json` doesn't match the git tag, the workflow will show a warning but will still create the release. Make sure to keep these in sync.
+
+### Failed Release
+
+If the release fails, check the GitHub Actions logs at:
+`https://github.com/graphaelli/kb-ascode-browser/actions`
+
+Common issues:
+- Missing permissions (workflow needs `contents: write` permission)
+- Invalid tag format (must be `v*.*.*`)
+- Network issues during artifact upload


### PR DESCRIPTION
Automate GitHub releases for the Chrome extension by adding a GitHub Actions workflow.

This PR addresses issue #2 by setting up a `release.yml` workflow that triggers on version tags (e.g., `v1.0.1`). It packages the extension, generates a changelog, and creates a GitHub release with the packaged artifact. It also includes `RELEASING.md` with instructions and best practices for the new automated release process.

---
[Slack Thread](https://elastic.slack.com/archives/D0AC9PDG9NG/p1769991529319039?thread_ts=1769991529.319039&cid=D0AC9PDG9NG)

<a href="https://cursor.com/background-agent?bcId=bc-8a2dba91-171b-59e7-b6e6-ae739eb60712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a2dba91-171b-59e7-b6e6-ae739eb60712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds release automation and documentation only; the main impact is on the repo’s release/publishing pipeline (tag-triggered workflow) rather than runtime code.
> 
> **Overview**
> Adds a tag-triggered GitHub Actions workflow (`.github/workflows/release.yml`) that packages the Chrome extension into a versioned ZIP, generates a changelog from commits since the previous tag, and publishes a GitHub Release (plus an uploaded artifact). It also warns (without failing) if the `manifest.json` version doesn’t match the pushed tag.
> 
> Adds `RELEASING.md` documenting the new release process, tag format, packaged contents, and troubleshooting guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 132eff4dbf32ea8a7ccbd216496dfc1ee71a5537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->