### PR TITLE
Dashboard element colors

### DIFF
--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -177,7 +177,7 @@ header h1 {
 }
 
 .resource-type {
-  background: #006bb4;
+  background: #006bb4; /* Fallback color if inline style not applied */
   color: white;
   padding: 2px 8px;
   border-radius: 4px;
@@ -190,14 +190,8 @@ header h1 {
   background: #98a2b3;
 }
 
-.resource-type.embedded {
-  background: #7c3aed;
-}
-
-.resource-type.alt-api {
-  background: #0d9488;
-}
-
+/* Color is now dynamically generated via inline styles based on type+subtype */
+/* Keep not-exportable as gray to indicate disabled state */
 .resource-type.not-exportable {
   background: #98a2b3;
 }

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -100,7 +100,7 @@ function renderResourceItem(resource, index) {
         <div class="resource-info">
           <div class="resource-title">${escapeHtml(resource.title || 'Untitled')}</div>
           <div class="resource-meta">
-            <span class="resource-type${isEmbedded ? ' embedded' : ''}${usesAltApi ? ' alt-api' : ''}${isNotExportable ? ' not-exportable' : ''}" ${typeColorStyle}>${escapeHtml(typeLabel)}</span>
+            <span class="resource-type${isNotExportable ? ' not-exportable' : ''}" ${typeColorStyle}>${escapeHtml(typeLabel)}</span>
             ${resource.id ? `<span class="resource-id" title="${escapeHtml(resource.id)}">${escapeHtml(resource.id)}</span>` : ''}
           </div>
           ${isNotExportable ? `<div class="not-exportable-reason">${escapeHtml(disabledReason)}</div>` : ''}


### PR DESCRIPTION
Implement deterministic color generation for dashboard element types and subtypes to improve visual differentiation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7361f89b-6142-4301-bc58-f47dddee4383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7361f89b-6142-4301-bc58-f47dddee4383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds inline styling for type badges; main risk is minor visual/accessibility regressions (contrast or color collisions) and unexpected styling from user-provided type strings.
> 
> **Overview**
> Adds deterministic, per-resource coloring for the sidepanel’s `.resource-type` badges by generating an HSL color from the resource `type`/`subType` and applying it via inline `background-color`.
> 
> Removes the previous hardcoded CSS variants (e.g., `embedded`, `alt-api`) for badge coloring, keeps `.not-exportable` explicitly gray, and leaves a default CSS fallback color if inline styles aren’t applied.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f50b97837fa1940f572695e06f7d799b776ef2f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->