### PR TITLE
Use PAT for issue triage comments

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -39,6 +39,7 @@ jobs:
         if: steps.check_collaborator.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.TRIAGE_PAT }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
Post triage comments as a user instead of github-actions bot so Cursor will process the @cursor mention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk workflow tweak that only changes the auth token used to create an issue comment. Main risk is misconfiguration or overly-permissive `TRIAGE_PAT` secret affecting who posts and with what permissions.
> 
> **Overview**
> Updates `.github/workflows/issue-triage.yml` so the "Request Cursor Agent triage" step uses `github-token: ${{ secrets.TRIAGE_PAT }}` when calling `issues.createComment`.
> 
> This makes triage comments post as the PAT user (rather than `github-actions`), ensuring the `@cursor` mention is processed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 479538f30802ad2b661371d5d3348c063ff6cdae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->