### PR TITLE
Redefine trivial fix more broadly

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,5 +45,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `@cursor please investigate this issue and provide analysis. Determine if it's a bug, enhancement, or question. Review the codebase for context. If it's a trivial fix (< 10 lines), you may open a PR. Otherwise, suggest a plan and await review.`
+              body: `@cursor please investigate this issue and provide analysis. Determine if it's a bug, enhancement, or question. Review the codebase for context. If it's a trivial fix (simple changes like renaming, logging level adjustments, typos, or straightforward replacements, even across multiple files), open a PR directly. Otherwise, suggest a plan and await review.`
             });


### PR DESCRIPTION
Update issue triage prompt to redefine "trivial fix" based on complexity instead of line count.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e8d1c93-cd1b-4ed1-9b95-72d185250a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e8d1c93-cd1b-4ed1-9b95-72d185250a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the issue-triage workflow comment text and does not change runtime code or permissions. Risk is limited to potentially increasing how often the Cursor agent auto-opens PRs.
> 
> **Overview**
> Updates `.github/workflows/issue-triage.yml` to broaden the Cursor Agent triage instructions: instead of using a strict `< 10 lines` threshold, it now defines *trivial fixes* by **low complexity** examples (renames, logging level tweaks, typos, straightforward replacements) and allows opening PRs directly even if changes span multiple files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4fbf12830cdcc6873cc4dc541fa78eb1e552cda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->