### PR TITLE
New issue triage comment

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,5 +45,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `@cursor please investigate this issue and provide analysis. Determine if it's a bug, enhancement, or question. Review the codebase for context. If it's a trivial fix (simple changes like renaming, logging level adjustments, typos, or straightforward replacements, even across multiple files), open a PR directly. Otherwise, suggest a plan and await review.`
+              body: `@cursor please investigate this issue and provide analysis. Determine if it's a bug, enhancement, or question. Review the codebase for context. If it's a trivial fix (simple changes like renaming, logging level adjustments, typos, or straightforward replacements, even across multiple files), open a PR directly. Otherwise, suggest a plan and await review.
+
+**Important:** If you create a PR, include "Closes #${context.payload.issue.number}" in the PR description to automatically link and close this issue when merged.`
             });


### PR DESCRIPTION
Update issue triage workflow to remind @cursor to include issue numbers in PR descriptions.

---
<a href="https://cursor.com/background-agent?bcId=bc-0574928d-8427-430c-9d36-ed684c8ff6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0574928d-8427-430c-9d36-ed684c8ff6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

closes #11 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the text of an automated issue comment in a GitHub Actions workflow, with no code or runtime behavior changes beyond the message content.
> 
> **Overview**
> Updates the issue triage GitHub Action (`.github/workflows/issue-triage.yml`) to add an **Important** reminder in the Cursor agent comment: when opening a PR for a trivial fix, include `Closes #<issue number>` in the PR description so the issue auto-links and closes on merge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8c52fe4a2b10e8bea7deaf318391b1cc569ebad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->