### PR TITLE
Debugging mode issue

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -1,5 +1,8 @@
 // Background service worker for Kibana as Code - handles file downloads
 
+// Import logger
+importScripts('../shared/logger.js');
+
 /**
  * Sanitize a string for use as a filename
  */
@@ -67,7 +70,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         
         sendResponse({ success: true, filename });
       } catch (error) {
-        console.error('[Kibana as Code] Download error:', error);
+        logger.error('Download error:', error);
         sendResponse({ success: false, error: error.message });
       }
     })();
@@ -78,4 +81,4 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 // Log service worker activation
-console.log('[Kibana as Code] Background service worker started');
+logger.log('Background service worker started');

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -212,7 +212,13 @@ footer {
   margin-top: 16px;
   padding-top: 12px;
   border-top: 1px solid #d3dae6;
-  text-align: center;
+}
+
+.footer-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
 }
 
 footer a {
@@ -228,6 +234,30 @@ footer a:hover {
 .footer-text {
   font-size: 12px;
   color: #69707d;
+}
+
+/* Debug toggle */
+.debug-toggle {
+  flex-shrink: 0;
+}
+
+.debug-toggle label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  color: #69707d;
+}
+
+.debug-toggle input[type="checkbox"] {
+  cursor: pointer;
+  width: 14px;
+  height: 14px;
+}
+
+.toggle-label {
+  user-select: none;
 }
 
 /* Center text in states */

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -103,10 +103,19 @@
     </main>
 
     <footer>
-      <span class="footer-text">Export Kibana resources as code</span>
+      <div class="footer-content">
+        <span class="footer-text">Export Kibana resources as code</span>
+        <div class="debug-toggle">
+          <label for="debug-mode-toggle" title="Enable debug logging in browser console">
+            <input type="checkbox" id="debug-mode-toggle">
+            <span class="toggle-label">Debug Mode</span>
+          </label>
+        </div>
+      </div>
     </footer>
   </div>
 
+  <script src="../shared/logger.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -4,6 +4,20 @@
 let currentSavedObject = null;
 let currentTabId = null;
 
+// Initialize debug toggle
+async function initDebugToggle() {
+  const debugToggle = document.getElementById('debug-mode-toggle');
+  
+  // Load current setting
+  const result = await chrome.storage.local.get('debugModeEnabled');
+  debugToggle.checked = result.debugModeEnabled || false;
+  
+  // Listen for changes
+  debugToggle.addEventListener('change', async (e) => {
+    await logger.setDebugEnabled(e.target.checked);
+  });
+}
+
 // DOM elements
 const states = {
   loading: document.getElementById('loading'),
@@ -95,7 +109,7 @@ async function getSavedObjectInfo() {
       showState('notDetected');
     }
   } catch (error) {
-    // console.error('[Kibana as Code] Error detecting resource:', error);
+    logger.error('Error detecting resource:', error);
     showState('notDetected');
   }
 }
@@ -149,7 +163,7 @@ async function exportSavedObject() {
       showState('error');
     }
   } catch (error) {
-    console.error('Export error:', error);
+    logger.error('Export error:', error);
     elements.errorMessage.textContent = error.message || 'Failed to export resource';
     showState('error');
   }
@@ -172,7 +186,7 @@ async function openSidePanel() {
     // Close the popup
     window.close();
   } catch (error) {
-    console.warn('[Kibana as Code] Error opening side panel:', error);
+    logger.warn('Error opening side panel:', error);
   }
 }
 
@@ -184,5 +198,6 @@ elements.ndExploreBtn.addEventListener('click', openSidePanel);
 elements.retryBtn.addEventListener('click', retryExport);
 
 // Initialize popup
+initDebugToggle();
 showState('loading');
 getSavedObjectInfo();

--- a/shared/logger.js
+++ b/shared/logger.js
@@ -1,0 +1,124 @@
+// Centralized logging utility for Kibana as Code
+// Respects the user's debug mode setting
+
+/**
+ * Logger class that respects debug mode setting
+ */
+class Logger {
+  constructor(prefix = '[Kibana as Code]') {
+    this.prefix = prefix;
+    this._debugEnabled = false;
+    this._initialized = false;
+    this._initPromise = null;
+  }
+
+  /**
+   * Initialize logger by loading debug setting from storage
+   */
+  async init() {
+    if (this._initialized) {
+      return;
+    }
+
+    if (this._initPromise) {
+      return this._initPromise;
+    }
+
+    this._initPromise = (async () => {
+      try {
+        const result = await chrome.storage.local.get('debugModeEnabled');
+        this._debugEnabled = result.debugModeEnabled || false;
+        this._initialized = true;
+      } catch (error) {
+        // If storage fails, default to disabled
+        this._debugEnabled = false;
+        this._initialized = true;
+      }
+    })();
+
+    return this._initPromise;
+  }
+
+  /**
+   * Get current debug state (synchronous)
+   */
+  isDebugEnabled() {
+    return this._debugEnabled;
+  }
+
+  /**
+   * Set debug state and persist to storage
+   */
+  async setDebugEnabled(enabled) {
+    this._debugEnabled = enabled;
+    try {
+      await chrome.storage.local.set({ debugModeEnabled: enabled });
+    } catch (error) {
+      console.error('Failed to save debug setting:', error);
+    }
+  }
+
+  /**
+   * Log info message (only if debug mode is enabled)
+   */
+  log(...args) {
+    if (this._debugEnabled) {
+      console.log(this.prefix, ...args);
+    }
+  }
+
+  /**
+   * Log warning message (only if debug mode is enabled)
+   */
+  warn(...args) {
+    if (this._debugEnabled) {
+      console.warn(this.prefix, ...args);
+    }
+  }
+
+  /**
+   * Log error message (only if debug mode is enabled)
+   */
+  error(...args) {
+    if (this._debugEnabled) {
+      console.error(this.prefix, ...args);
+    }
+  }
+
+  /**
+   * Always log info message (regardless of debug mode)
+   * Use sparingly for critical information
+   */
+  alwaysLog(...args) {
+    console.log(this.prefix, ...args);
+  }
+
+  /**
+   * Always log warning message (regardless of debug mode)
+   * Use sparingly for critical warnings
+   */
+  alwaysWarn(...args) {
+    console.warn(this.prefix, ...args);
+  }
+
+  /**
+   * Always log error message (regardless of debug mode)
+   * Use sparingly for critical errors
+   */
+  alwaysError(...args) {
+    console.error(this.prefix, ...args);
+  }
+}
+
+// Create singleton instance
+const logger = new Logger('[Kibana as Code]');
+
+// Initialize immediately
+logger.init();
+
+// Listen for changes to debug setting
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes.debugModeEnabled) {
+    logger._debugEnabled = changes.debugModeEnabled.newValue || false;
+  }
+});

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -43,6 +43,7 @@
     </main>
   </div>
 
+  <script src="../shared/logger.js"></script>
   <script src="sidepanel.js"></script>
 </body>
 </html>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -209,7 +209,7 @@ async function handleDownload(index, button) {
       throw new Error(response.error || 'Export failed');
     }
   } catch (error) {
-    console.error('[Kibana as Code] Export error:', error);
+    logger.error('Export error:', error);
     
     button.classList.remove('downloading');
     button.classList.add('error');
@@ -270,7 +270,7 @@ async function scanForResources() {
       showState('no-resources');
     }
   } catch (error) {
-    console.warn('[Kibana as Code] Error scanning for resources:', error);
+    logger.warn('Error scanning for resources:', error);
     showState('no-resources');
   }
 }


### PR DESCRIPTION
Add a user-controllable debug mode with a centralized logger and UI toggle to manage console logging.

This enhancement introduces a `shared/logger.js` utility and a toggle in the popup to allow users to enable or disable console output from the extension, which defaults to off.
Closes #17

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5f2d4400-b986-45a1-aca7-f2cf294fc8e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f2d4400-b986-45a1-aca7-f2cf294fc8e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily affects logging and a small popup UI toggle; behavior changes are limited to console output and storing a boolean in extension storage.
> 
> **Overview**
> Adds a centralized `shared/logger.js` that persists a `debugModeEnabled` flag in `chrome.storage.local`, updates logger state on storage changes, and is loaded by the popup, side panel, and background worker.
> 
> Replaces most direct `console.*` calls in the background worker, popup, side panel, and content script with gated `logger.log/warn/error`, and introduces a **popup Debug Mode checkbox** to let users enable/disable console output (default off).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20084737e05b0f0a134adc206d8e2249798e1ecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->